### PR TITLE
[Bugfix] Throw invalid uris when no scheme is parsed

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -82,6 +82,10 @@ class Uri implements Stringable
 
         $scheme = Str\toLower($parts['scheme'] ?? '');
 
+        if ('' === $scheme) {
+            throw new InvalidUri('Uri must have a scheme');
+        }
+
         return new self(
             $scheme,
             $parts['user'] ?? '',

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -27,7 +27,7 @@ use PHPUnit\Framework\TestCase;
 class UriTest extends TestCase
 {
     /**
-     * @dataProvider getUris
+     * @dataProvider getValidUris
      *
      * @throws InvalidUri
      */
@@ -36,7 +36,18 @@ class UriTest extends TestCase
         self::assertSame($parsed, Uri::parse($uri)->toStr());
     }
 
-    public function getUris(): array
+    /**
+     * @dataProvider  getInvalidUris
+     *
+     * @throws InvalidUri
+     */
+    public function testInvalidUris(string $uri): void
+    {
+        $this->expectException(InvalidUri::class);
+        Uri::parse($uri);
+    }
+
+    public function getValidUris(): array
     {
         return [
             ['https://example.com', 'https://example.com'],
@@ -44,6 +55,13 @@ class UriTest extends TestCase
             ['ftp://user:pass@some.host/file.txt', 'ftp://user:pass@some.host/file.txt'],
             ['tel:+1-816-555-1212', 'tel:+1-816-555-1212'],
             ['mailto:John.Doe@example.com', 'mailto:John.Doe@example.com'],
+        ];
+    }
+
+    public function getInvalidUris(): array
+    {
+        return [
+            ['://example.com/protocol-relative-url'],
         ];
     }
 }


### PR DESCRIPTION
A valid uri must have a scheme. We do not treat uris without a scheme as valid.

Closes #3